### PR TITLE
Docstring documentation of connections and panel assembly

### DIFF
--- a/compmech/panel/assembly/assembly.py
+++ b/compmech/panel/assembly/assembly.py
@@ -53,7 +53,7 @@ class PanelAssembly(object):
     >>> panels = [panel_1, panel_2]
     >>> conn = [
             dict(p1=panel_1, p2=panel_2, func='SSxcte', xcte1=0, xcte2=panel_2.a),
-            dict(p1=panel_2, p2=panel_3, func='SSycte', xcte1=0, xcte2=panel_3.b)
+            dict(p1=panel_2, p2=panel_3, func='SSycte', ycte1=0, ycte2=panel_3.b)
             ] # A list of dictionary that indicates two connections: (panel_1-panel_2) and (panel_2-panel_3)
     >>> assembly_1 = PanelAssembly(panels, conn)
 
@@ -64,12 +64,12 @@ class PanelAssembly(object):
     builds the compatibility relations between the panels.
 
     The connections functions available are:
-        - 'SSycte' : defines a skin-skin connection and calls the following functions ```fkCSSycte11```, ```fkCSSycte12```, ```fkCSSycte22``` 
-        - 'SSxcte' : defines a skin-skin connection and calls the following functions ```fkCSSxcte11```, ```fkCSSxcte12```, ```fkCSSxcte22```
-        - 'SB' : defines a skin-base connection and calls the following functions ```fkCBFycte11```, ```fkCBFycte12```, ```fkCBFycte22```
-        - 'BFycte': defines a base-flange connection and calls the following functions ```fkCBFycte11```, ```fkCBFycte12```, ```fkCBFycte22```
+        - 'SSycte' : defines a skin-skin connection and calls the following functions ``fkCSSycte11``, ``fkCSSycte12``, ``fkCSSycte22`` 
+        - 'SSxcte' : defines a skin-skin connection and calls the following functions ``fkCSSxcte11``, ``fkCSSxcte12``, ``fkCSSxcte22``
+        - 'SB' : defines a skin-base connection and calls the following functions ``fkCBFycte11``, ``fkCBFycte12``, ``fkCBFycte22``
+        - 'BFycte': defines a base-flange connection and calls the following functions ``fkCBFycte11``, ``fkCBFycte12``, ``fkCBFycte22``
 
-    Explanations about the connetion functions are found in ```connections``` module.
+    Explanations about the connetion functions are found in ``connections`` module.
     """
     def __init__(self, panels):
         self.conn = None

--- a/compmech/panel/assembly/assembly.py
+++ b/compmech/panel/assembly/assembly.py
@@ -45,6 +45,31 @@ class PanelAssembly(object):
     conn : dict
         A connectivity dictionary.
 
+    Example
+    -------
+    >>> panel_1 = Panel(*args)
+    >>> panel_2 = Panel(*args)
+    >>> panel_3 = Panel(*args)
+    >>> panels = [panel_1, panel_2]
+    >>> conn = [
+            dict(p1=panel_1, p2=panel_2, func='SSxcte', xcte1=0, xcte2=panel_2.a),
+            dict(p1=panel_2, p2=panel_3, func='SSycte', xcte1=0, xcte2=panel_3.b)
+            ] # A list of dictionary that indicates two connections: (panel_1-panel_2) and (panel_2-panel_3)
+    >>> assembly_1 = PanelAssembly(panels, conn)
+
+    Notes
+    -----
+
+    Concerning the conn dictionary, the key 'func' stands for the connection function that 
+    builds the compatibility relations between the panels.
+
+    The connections functions available are:
+        - 'SSycte' : defines a skin-skin connection and calls the following functions ```fkCSSycte11```, ```fkCSSycte12```, ```fkCSSycte22``` 
+        - 'SSxcte' : defines a skin-skin connection and calls the following functions ```fkCSSxcte11```, ```fkCSSxcte12```, ```fkCSSxcte22```
+        - 'SB' : defines a skin-base connection and calls the following functions ```fkCBFycte11```, ```fkCBFycte12```, ```fkCBFycte22```
+        - 'BFycte': defines a base-flange connection and calls the following functions ```fkCBFycte11```, ```fkCBFycte12```, ```fkCBFycte22```
+
+    Explanations about the connetion functions are found in ```connections``` module.
     """
     def __init__(self, panels):
         self.conn = None

--- a/compmech/panel/connections/kCBFycte.pyx
+++ b/compmech/panel/connections/kCBFycte.pyx
@@ -32,6 +32,35 @@ cdef int num = 3
 
 def fkCBFycte11(double kt, double kr, object p1, double ycte1,
           int size, int row0, int col0):
+    '''
+    Penalty approach calculation to base-flange ycte panel 1 position.
+
+    Parameters
+    ----------
+    kt : float
+        Translation penalty stiffness.
+    kr : float
+        Rotation penalty stiffness.
+    p1 : Panel
+        Panel() object
+    ycte1 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    size : int
+        Size of assembly stiffness matrix, which are calculated by sum([3*p.m*p.n for p in self.panels]).
+        The size of the assembly can be calculated calling the PanelAssemly.get_size() method.
+    row0 : int
+        Row position of constitutive matrix being calculated.
+    col0 : int
+        Collumn position of constitutive matrix being calculated.
+
+    Returns
+    -------
+    kCBFycte11 : scipy.sparse.coo_matrix
+        A sparse matrix that adds the penalty stiffness to ycte of panel p1 position.
+    '''
+
     cdef int i1, j1, k1, l1, c, row, col
     cdef int m1, n1
     cdef double a1, b1
@@ -116,6 +145,40 @@ def fkCBFycte11(double kt, double kr, object p1, double ycte1,
 def fkCBFycte12(double kt, double kr, object p1, object p2,
           double ycte1, double ycte2,
           int size, int row0, int col0):
+    '''
+    Penalty approach calculation to base-flange ycte panel 1 and panel 2 coupling position.
+
+    Parameters
+    ----------
+    kt : float
+        Translation penalty stiffness.
+    kr : float
+        Rotation penalty stiffness.
+    p1 : Panel
+        First Panel object
+    p2 : Panel
+        Second Panel object
+    ycte1 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    ycte2 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    size : int
+        Size of assembly stiffness matrix, which are calculated by sum([3*p.m*p.n for p in self.panels]).
+        The size of the assembly can be calculated calling the PanelAssemly.get_size() method.
+    row0 : int
+        Row position of constitutive matrix being calculated.
+    col0 : int
+        Collumn position of constitutive matrix being calculated.
+
+    Returns
+    -------
+    kCBFycte12 : scipy.sparse.coo_matrix
+        A sparse matrix that adds the penalty stiffness to ycte of panel 1 and panel 2 coupling position.
+    '''
     cdef int i1, j1, k2, l2, c, row, col
     cdef int m1, n1, m2, n2
     cdef double a1, b1, b2
@@ -216,6 +279,36 @@ def fkCBFycte12(double kt, double kr, object p1, object p2,
 def fkCBFycte22(double kt, double kr, object p1, object p2,
           double ycte2,
           int size, int row0, int col0):
+    '''
+    Penalty approach calculation to base-flange ycte panel 2 position.
+
+    Parameters
+    ----------
+    kt : float
+        Translation penalty stiffness.
+    kr : float
+        Rotation penalty stiffness.
+    p1 : Panel
+        First Panel object
+    p2 : Panel
+        Second Panel object
+    ycte2 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    size : int
+        Size of assembly stiffness matrix, which are calculated by sum([3*p.m*p.n for p in self.panels]).
+        The size of the assembly can be calculated calling the PanelAssemly.get_size() method.
+    row0 : int
+        Row position of constitutive matrix being calculated.
+    col0 : int
+        Collumn position of constitutive matrix being calculated.
+
+    Returns
+    -------
+    kCBFycte22 : scipy.sparse.coo_matrix
+        A sparse matrix that adds the penalty stiffness to ycte of panel p2 position.
+    '''
     cdef int i2, k2, j2, l2, c, row, col
     cdef int m2, n2
     cdef double a1, b2

--- a/compmech/panel/connections/kCSB.pyx
+++ b/compmech/panel/connections/kCSB.pyx
@@ -35,9 +35,36 @@ INT = np.int64
 
 cdef int num = 3
 
-
+# TODO: explain dsb parameter
 def fkCSB11(double kt, double dsb, object p1,
             int size, int row0, int col0):
+    '''
+    Penalty approach calculation to skin-base ycte panel 1 position.
+
+    Parameters
+    ----------
+    kt : float
+        Translation penalty stiffness.
+    dsb : float
+    p1 : Panel
+        Panel() object
+    ycte1 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    size : int
+        Size of assembly stiffness matrix, which are calculated by sum([3*p.m*p.n for p in self.panels]).
+        The size of the assembly can be calculated calling the PanelAssemly.get_size() method.
+    row0 : int
+        Row position of constitutive matrix being calculated.
+    col0 : int
+        Collumn position of constitutive matrix being calculated.
+
+    Returns
+    -------
+    kCSB11 : scipy.sparse.coo_matrix
+        A sparse matrix that adds the penalty stiffness to ycte of panel p1 position.
+    '''
     cdef int i1, k1, j1, l1, c, row, col
     cdef int m1, n1
     cdef double a1, b1
@@ -137,8 +164,42 @@ def fkCSB11(double kt, double dsb, object p1,
     return kCSB11
 
 
+# TODO: explain dsb parameter
 def fkCSB12(double kt, double dsb, object p1, object p2,
             int size, int row0, int col0):
+    '''
+    Penalty approach calculation to skin-base ycte panel 1 and panel 2 coupling position.
+
+    Parameters
+    ----------
+    kt : float
+        Translation penalty stiffness.
+    dsb : float
+    p1 : Panel
+        First Panel object
+    p2 : Panel
+        Second Panel object
+    ycte1 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    ycte2 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    size : int
+        Size of assembly stiffness matrix, which are calculated by sum([3*p.m*p.n for p in self.panels]).
+        The size of the assembly can be calculated calling the PanelAssemly.get_size() method.
+    row0 : int
+        Row position of constitutive matrix being calculated.
+    col0 : int
+        Collumn position of constitutive matrix being calculated.
+
+    Returns
+    -------
+    kCBFycte12 : scipy.sparse.coo_matrix
+        A sparse matrix that adds the penalty stiffness to ycte of panel 1 and panel 2 coupling position.
+    '''
     cdef int i1, j1, k2, l2, c, row, col
     cdef int m1, n1, m2, n2
     cdef double a1, b1
@@ -235,6 +296,35 @@ def fkCSB12(double kt, double dsb, object p1, object p2,
 
 def fkCSB22(double kt, object p1, object p2,
             int size, int row0, int col0):
+    '''
+    Penalty approach calculation to skin-base ycte panel 2 position.
+
+    Parameters
+    ----------
+    kt : float
+        Translation penalty stiffness.
+    p1 : Panel
+        First Panel object
+    p2 : Panel
+        Second Panel object
+    ycte2 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    size : int
+        Size of assembly stiffness matrix, which are calculated by sum([3*p.m*p.n for p in self.panels]).
+        The size of the assembly can be calculated calling the PanelAssemly.get_size() method.
+    row0 : int
+        Row position of constitutive matrix being calculated.
+    col0 : int
+        Collumn position of constitutive matrix being calculated.
+
+    Returns
+    -------
+    kCSB22 : scipy.sparse.coo_matrix
+        A sparse matrix that adds the penalty stiffness to ycte of panel p2 position.
+    '''
+
     cdef int i2, k2, j2, l2, c, row, col
     cdef int m2, n2
     cdef double a1, b1

--- a/compmech/panel/connections/kCSSxcte.pyx
+++ b/compmech/panel/connections/kCSSxcte.pyx
@@ -33,6 +33,34 @@ cdef int num = 3
 def fkCSSxcte11(double kt, double kr, object p1,
                 double xcte1,
                 int size, int row0, int col0):
+    '''
+    Penalty approach calculation to skin-skin xcte panel 1 position.
+
+    Parameters
+    ----------
+    kt : float
+        Translation penalty stiffness.
+    kr : float
+        Rotation penalty stiffness.
+    p1 : Panel
+        Panel() object
+    xcte1 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    size : int
+        Size of assembly stiffness matrix, which are calculated by sum([3*p.m*p.n for p in self.panels]).
+        The size of the assembly can be calculated calling the PanelAssemly.get_size() method.
+    row0 : int
+        Row position of constitutive matrix being calculated.
+    col0 : int
+        Collumn position of constitutive matrix being calculated.
+
+    Returns
+    -------
+    kCSSxcte11 : scipy.sparse.coo_matrix
+        A sparse matrix that adds the penalty stiffness to xcte of panel p1 position.
+    '''
     cdef int i1, k1, j1, l1, c, row, col
     cdef int m1, n1
     cdef double a1, b1
@@ -117,6 +145,40 @@ def fkCSSxcte11(double kt, double kr, object p1,
 def fkCSSxcte12(double kt, double kr, object p1, object p2,
                 double xcte1, double xcte2,
                 int size, int row0, int col0):
+    '''
+    Penalty approach calculation to skin-skin xcte panel 1 and panel 2 coupling position.
+
+    Parameters
+    ----------
+    kt : float
+        Translation penalty stiffness.
+    kr : float
+        Rotation penalty stiffness.
+    p1 : Panel
+        First Panel object
+    p2 : Panel
+        Second Panel object
+    xcte1 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    xcte2 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    size : int
+        Size of assembly stiffness matrix, which are calculated by sum([3*p.m*p.n for p in self.panels]).
+        The size of the assembly can be calculated calling the PanelAssemly.get_size() method.
+    row0 : int
+        Row position of constitutive matrix being calculated.
+    col0 : int
+        Collumn position of constitutive matrix being calculated.
+
+    Returns
+    -------
+    kCSSxcte12 : scipy.sparse.coo_matrix
+        A sparse matrix that adds the penalty stiffness to xcte of panel 1 and panel 2 coupling position.
+    '''
     cdef int i1, k2, j1, l2, c, row, col
     cdef int m1, n1, m2, n2
     cdef double a1, a2, b1, b2
@@ -213,6 +275,36 @@ def fkCSSxcte12(double kt, double kr, object p1, object p2,
 def fkCSSxcte22(double kt, double kr, object p1, object p2,
                 double xcte2,
                 int size, int row0, int col0):
+    '''
+    Penalty approach calculation to skin-skin ycte panel 2 position.
+
+    Parameters
+    ----------
+    kt : float
+        Translation penalty stiffness.
+    kr : float
+        Rotation penalty stiffness.
+    p1 : Panel
+        First Panel object
+    p2 : Panel
+        Second Panel object
+    xcte2 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    size : int
+        Size of assembly stiffness matrix, which are calculated by sum([3*p.m*p.n for p in self.panels]).
+        The size of the assembly can be calculated calling the PanelAssemly.get_size() method.
+    row0 : int
+        Row position of constitutive matrix being calculated.
+    col0 : int
+        Collumn position of constitutive matrix being calculated.
+
+    Returns
+    -------
+    kCSSxcte22 : scipy.sparse.coo_matrix
+        A sparse matrix that adds the penalty stiffness to xcte of panel p2 position.
+    '''
     cdef int i2, k2, j2, l2, c, row, col
     cdef int m2, n2
     cdef double b1, a2, b2

--- a/compmech/panel/connections/kCSSycte.pyx
+++ b/compmech/panel/connections/kCSSycte.pyx
@@ -34,6 +34,34 @@ cdef int num = 3
 
 def fkCSSycte11(double kt, double kr, object p1, double ycte1,
         int size, int row0, int col0):
+    '''
+    Penalty approach calculation to skin-skin ycte panel 1 position.
+
+    Parameters
+    ----------
+    kt : float
+        Translation penalty stiffness.
+    kr : float
+        Rotation penalty stiffness.
+    p1 : Panel
+        Panel() object
+    ycte1 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    size : int
+        Size of assembly stiffness matrix, which are calculated by sum([3*p.m*p.n for p in self.panels]).
+        The size of the assembly can be calculated calling the PanelAssemly.get_size() method.
+    row0 : int
+        Row position of constitutive matrix being calculated.
+    col0 : int
+        Collumn position of constitutive matrix being calculated.
+
+    Returns
+    -------
+    kCSSycte11 : scipy.sparse.coo_matrix
+        A sparse matrix that adds the penalty stiffness to ycte of panel p1 position.
+    '''
     cdef int i1, k1, j1, l1, c, row, col
     cdef int m1, n1
     cdef double a1, b1
@@ -119,6 +147,40 @@ def fkCSSycte11(double kt, double kr, object p1, double ycte1,
 def fkCSSycte12(double kt, double kr, object p1, object p2,
           double ycte1, double ycte2,
           int size, int row0, int col0):
+    '''
+    Penalty approach calculation to skin-skin ycte panel 1 and panel 2 coupling position.
+
+    Parameters
+    ----------
+    kt : float
+        Translation penalty stiffness.
+    kr : float
+        Rotation penalty stiffness.
+    p1 : Panel
+        First Panel object
+    p2 : Panel
+        Second Panel object
+    ycte1 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    ycte2 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    size : int
+        Size of assembly stiffness matrix, which are calculated by sum([3*p.m*p.n for p in self.panels]).
+        The size of the assembly can be calculated calling the PanelAssemly.get_size() method.
+    row0 : int
+        Row position of constitutive matrix being calculated.
+    col0 : int
+        Collumn position of constitutive matrix being calculated.
+
+    Returns
+    -------
+    kCSSycte12 : scipy.sparse.coo_matrix
+        A sparse matrix that adds the penalty stiffness to ycte of panel 1 and panel 2 coupling position.
+    '''
     cdef int i1, k2, j1, l2, c, row, col
     cdef int m1, n1, m2, n2
     cdef double a1, b1, b2
@@ -216,6 +278,36 @@ def fkCSSycte12(double kt, double kr, object p1, object p2,
 def fkCSSycte22(double kt, double kr, object p1, object p2,
           double ycte2,
           int size, int row0, int col0):
+    '''
+    Penalty approach calculation to skin-skin ycte panel 2 position.
+
+    Parameters
+    ----------
+    kt : float
+        Translation penalty stiffness.
+    kr : float
+        Rotation penalty stiffness.
+    p1 : Panel
+        First Panel object
+    p2 : Panel
+        Second Panel object
+    ycte2 : float
+        Dimension value that determines the flag value eta.
+        If ycte1 = 0 => eta = -1, if ycte1 = p1.b => eta = 1.
+        Where eta=-1 stands for boundary 1 and eta=1 stands for boundary 2.
+    size : int
+        Size of assembly stiffness matrix, which are calculated by sum([3*p.m*p.n for p in self.panels]).
+        The size of the assembly can be calculated calling the PanelAssemly.get_size() method.
+    row0 : int
+        Row position of constitutive matrix being calculated.
+    col0 : int
+        Collumn position of constitutive matrix being calculated.
+
+    Returns
+    -------
+    kCSSycte22 : scipy.sparse.coo_matrix
+        A sparse matrix that adds the penalty stiffness to ycte of panel p2 position.
+    '''
     cdef int i2, k2, j2, l2, c, row, col
     cdef int m2, n2
     cdef double a1, b2

--- a/compmech/panel/connections/penalty_constants.py
+++ b/compmech/panel/connections/penalty_constants.py
@@ -25,6 +25,13 @@ def calc_kt_kr(p1, p2, connection_type):
     kt, kr : tuple
         A tuple with both values.
 
+    Note
+    ----
+    Theoretically, the penalty stiffnesses kt and kr can be arbitrarily high in order to impose the energy penalty. However, the
+    use of high values is associated with numerical instabilities such that one should choose the penalty stiffnesses that are just high
+    enough to impose the proper penalties, but not excessively high. In the current study it is proposed to calculate kt and kr based
+    on laminate properties of the panels being connected, instead of using fixed high values, a common practice in the literature.
+    [castro2017AssemblyModels]
     """
     def build_panel_lam(panel):
         panel._rebuild()


### PR DESCRIPTION
This PR adds docstring documentation in the functions of the **connections** module and an simple example in the PanelAsembly class constructor.

The docstrings has used information from ref. [1]

References
------------

[1] Castro, Saullo & Donadon, Mauricio. (2016). Assembly of Semi-Analytical models to Address Linear Buckling and Vibration of Stiffened Composite Panels with Debonding Defect. Composite Structures. 160. 10.1016/j.compstruct.2016.10.026. 